### PR TITLE
Update to 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DrinkBeer-Forge1.18.1
+# DrinkBeer-Forge1.18.2
 <h2 align="center">Useful Link</h2>
 
 <p align="center"><a href="https://github.com/Lekavar/DrinkBeer-Forge1.17.1-">Forge 1.17.1 Repo</a> | <a href="https://github.com/Lekavar/DrinkBeer-Forge1.16.5-">Forge 1.16.5 Repo</a> | <a href="https://www.curseforge.com/minecraft/mc-mods/drink-beer-forge">CurseForge</a></p>

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven-publish'
 
 version = '2.4.0'
 group = 'lekavar.lma' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'drinkbeer-1.18.1'
+archivesBaseName = 'drinkbeer-1.18.2'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17) // Mojang ships Java 8 to end users, so your mod should target Java 8.
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.18'
+    mappings channel: 'official', version: '1.18.2'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -117,7 +117,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.1-39.0.5'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/lekavar/lma/drinkbeer/DrinkBeer.java
+++ b/src/main/java/lekavar/lma/drinkbeer/DrinkBeer.java
@@ -18,6 +18,7 @@ public class DrinkBeer {
         SoundEventRegistry.SOUNDS.register(FMLJavaModLoadingContext.get().getModEventBus());
         MobEffectRegistry.STATUS_EFFECTS.register(FMLJavaModLoadingContext.get().getModEventBus());
         ContainerTypeRegistry.CONTAINERS.register(FMLJavaModLoadingContext.get().getModEventBus());
+        RecipeRegistry.RECIPE_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
         RecipeRegistry.RECIPE_SERIALIZERS.register(FMLJavaModLoadingContext.get().getModEventBus());
 
         // We just don't need these part now

--- a/src/main/java/lekavar/lma/drinkbeer/blockentities/BeerBarrelBlockEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/blockentities/BeerBarrelBlockEntity.java
@@ -75,7 +75,7 @@ public class BeerBarrelBlockEntity extends BaseContainerBlockEntity implements I
             // ingredient slots must have no empty slot
             if (!getIngredients().contains(ItemStack.EMPTY)) {
                 // Try match Recipe
-                BrewingRecipe recipe = level.getRecipeManager().getRecipeFor(RecipeRegistry.Type.BREWING, this, this.level).orElse(null);
+                BrewingRecipe recipe = level.getRecipeManager().getRecipeFor(RecipeRegistry.RECIPE_TYPE_BREWING.get(), this, this.level).orElse(null);
                 if (canBrew(recipe)) {
                     // Show Standard Brewing Time & Result
                     showPreview(recipe);

--- a/src/main/java/lekavar/lma/drinkbeer/recipes/BrewingRecipe.java
+++ b/src/main/java/lekavar/lma/drinkbeer/recipes/BrewingRecipe.java
@@ -115,12 +115,12 @@ public class BrewingRecipe implements Recipe<IBrewingInventory> {
 
     @Override
     public RecipeSerializer<?> getSerializer() {
-        return RecipeRegistry.BREWING.get();
+        return RecipeRegistry.RECIPE_SERIALIZER_BREWING.get();
     }
 
     @Override
     public RecipeType<?> getType() {
-        return RecipeRegistry.Type.BREWING;
+        return RecipeRegistry.RECIPE_TYPE_BREWING.get();
     }
 
     public int getRequiredCupCount() {

--- a/src/main/java/lekavar/lma/drinkbeer/registries/RecipeRegistry.java
+++ b/src/main/java/lekavar/lma/drinkbeer/registries/RecipeRegistry.java
@@ -1,17 +1,22 @@
 package lekavar.lma.drinkbeer.registries;
 
 import lekavar.lma.drinkbeer.recipes.BrewingRecipe;
+import net.minecraft.core.Registry;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
 public class RecipeRegistry {
-    public static class Type {
-        public static final RecipeType<BrewingRecipe> BREWING = RecipeType.register("drinkbeer:brewing");
-    }
+    public static final DeferredRegister<RecipeType<?>> RECIPE_TYPES = DeferredRegister.create(Registry.RECIPE_TYPE_REGISTRY, "drinkbeer");
+
+    public static final RegistryObject<RecipeType<BrewingRecipe>> RECIPE_TYPE_BREWING = RECIPE_TYPES.register("brewing", () -> new RecipeType<>() {
+        public String toString() {
+            return "brewing";
+        }
+    });
 
     public static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, "drinkbeer");
-    public static final RegistryObject<RecipeSerializer<BrewingRecipe>> BREWING = RECIPE_SERIALIZERS.register("brewing", BrewingRecipe.Serializer::new);
+    public static final RegistryObject<RecipeSerializer<BrewingRecipe>> RECIPE_SERIALIZER_BREWING = RECIPE_SERIALIZERS.register("brewing", BrewingRecipe.Serializer::new);
 }


### PR DESCRIPTION
Updates to 1.18.2.

Tested and confirmed working by @UdoMorgenstern, see https://github.com/Naetheline/DrinkBeer-Forge1.18.1/pull/2#issuecomment-1109659729.

Due to a breaking change, this **does** break the mod for 1.18.1.

### Changes
- Use DeferredRegister for registering recipe types to prevent adding recipes when registry has already been frozen
- Bumps forge version to `1.18.2-40.1.0`
